### PR TITLE
Improve CI & CD

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -26,6 +26,6 @@ jobs:
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macos-latest", "self-hosted"]'
+      runsonlabels: '["macOS", "self-hosted"]'
       fastlanelane: beta
       setupsigning: true

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -26,6 +26,6 @@ jobs:
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macOS"]'
+      runsonlabels: '["macos-latest"]'
       fastlanelane: beta
       setupsigning: true

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -27,5 +27,5 @@ jobs:
     with:
       runsonlabels: [macos-12]
       scheme: TemplateApplication
-      fastlanelane: test
+      fastlanelane: beta
       setupsigning: true

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -22,10 +22,10 @@ jobs:
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
     needs: buildandtest
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@feature/improveCI
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macOS", "self-hosted"]'
+      runsonlabels: '["macOS"]'
       fastlanelane: beta
       setupsigning: true

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -25,7 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
     secrets: inherit
     with:
-      runsonlabels: [self-hosted, macos]
+      runsonlabels: [macos-12]
       scheme: TemplateApplication
       fastlanelane: test
       setupsigning: true

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -21,51 +21,11 @@ jobs:
     secrets: inherit
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
-    runs-on: macos-12
     needs: buildandtest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        lfs: true
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Check Environment
-      run: |
-          xcodebuild -version
-          swift --version
-    - name: Install the Apple certificate and provisioning profile
-      env:
-        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-      run: |
-        # create variables
-        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-        PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-        # import certificate and provisioning profile from secrets
-        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-        echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode --output $PP_PATH
-
-        # create temporary keychain
-        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-        # import certificate to keychain
-        security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-        security list-keychain -d user -s $KEYCHAIN_PATH
-
-        # apply provisioning profile
-        mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-        cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
-    - name: Build and test
-      run: bundler install && bundle exec fastlane beta
-      env:
-        APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-        APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-        APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
-        APPLE_ID: ${{ secrets.APPLE_ID }}
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
+    secrets: inherit
+    with:
+      runsonlabels: [self-hosted, macos]
+      scheme: TemplateApplication
+      fastlanelane: test
+      setupsigning: true

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -22,7 +22,7 @@ jobs:
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
     needs: buildandtest
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@feature/improveCI
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -25,7 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     secrets: inherit
     with:
-      runsonlabels: [macos-12]
-      scheme: TemplateApplication
+      artifactname: TemplateApplication.xcresult
+      runsonlabels: '["macOS", "self-hosted"]'
       fastlanelane: beta
       setupsigning: true

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -26,6 +26,6 @@ jobs:
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macOS", "self-hosted"]'
+      runsonlabels: '["macos-latest", "self-hosted"]'
       fastlanelane: beta
       setupsigning: true

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -22,7 +22,7 @@ jobs:
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
     needs: buildandtest
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     secrets: inherit
     with:
       runsonlabels: [macos-12]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: TemplateApplication
       setupfirebaseemulator: true
-      customcommand: "firebase emulators:exec 'bundler install && bundle exec fastlane test'"
+      customcommand: "firebase emulators:exec 'fastlane test'"
   buildandtestongithub:
     name: Build and Test
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,15 @@ jobs:
       scheme: TemplateApplication
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'bundler install && bundle exec fastlane test'"
+  buildandtestongithub:
+    name: Build and Test
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
+    secrets: inherit
+    with:
+      runsonlabels: '["macos-12"]'
+      scheme: TemplateApplication
+      setupfirebaseemulator: true
+      customcommand: "firebase emulators:exec 'bundler install && bundle exec fastlane test'"
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: buildandtest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macos-latest"]'
+      runsonlabels: '["macOS", "self-hosted"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,47 +20,16 @@ jobs:
   swiftlint:
     name: SwiftLint
     uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
-  buildandtestiosapp:
-    name: Build and Test iOS App
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        lfs: true
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Check Environment
-      run: |
-          xcodebuild -version
-          swift --version
-    - name: Cache Firebase Emulators
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/firebase/emulators
-        key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
-    - name: Setup NodeJS
-      uses: actions/setup-node@v3
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'microsoft'
-        java-version: '17'
-    - name: Install Firebase CLI Tools
-      run: npm install -g firebase-tools
-    - name: Build and Test Example App
-      run: |
-          firebase emulators:exec 'bundler install && bundle exec fastlane test'
-    - name: Upload Artifact
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        name: TemplateApplication.xcresult
-        path: TemplateApplication.xcresult
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-        xcode: true
-        xcode_archive_path: TemplateApplication.xcresult
+  buildandtest:
+    name: Build and Test
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
+    secrets: inherit
+    with:
+      runsonlabels: [self-hosted, macos]
+      scheme: TemplateApplication
+      fastlanelane: test
+  uploadcoveragereport:
+    name: Upload Coverage Report
+    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report@selfHostedCI
+    with:
+      coveragereports: TemplateApplication.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
     secrets: inherit
     with:
-      runsonlabels: [self-hosted, macos]
+      runsonlabels: [macos-12]
       scheme: TemplateApplication
       fastlanelane: test
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,6 @@ jobs:
   buildandtest:
     name: Build and Test
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
       runsonlabels: '["macOS", "self-hosted"]'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
   buildandtest:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@feature/improveCI
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,15 +29,6 @@ jobs:
       runsonlabels: '["macOS", "self-hosted"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
-  buildandtestongithub:
-    name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    secrets: inherit
-    with:
-      artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macos-12"]'
-      setupfirebaseemulator: true
-      customcommand: "firebase emulators:exec 'bundler install && bundle exec fastlane test'"
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: buildandtest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macOS", "self-hosted"]'
+      runsonlabels: '["macos-latest", "self-hosted"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
     secrets: inherit
     with:
-      runsonlabels: '["macos-12"]'
+      runsonlabels: '["macos-12", "self-hosted"]'
       scheme: TemplateApplication
       fastlanelane: test
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
     secrets: inherit
     with:
-      runsonlabels: [macos-12]
+      runsonlabels: '["macos-12"]'
       scheme: TemplateApplication
       fastlanelane: test
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
     secrets: inherit
     with:
+      artifactname: TemplateApplication.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
@@ -33,6 +34,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
     secrets: inherit
     with:
+      artifactname: TemplateApplication.xcresult
       runsonlabels: '["macos-12"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'bundler install && bundle exec fastlane test'"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macOS"]'
+      runsonlabels: '["macos-latest"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,6 @@ jobs:
       fastlanelane: test
   uploadcoveragereport:
     name: Upload Coverage Report
-    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report@selfHostedCI
+    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@selfHostedCI
     with:
       coveragereports: TemplateApplication.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,11 +22,11 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
   buildandtest:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@feature/improveCI
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macOS", "self-hosted"]'
+      runsonlabels: '["macOS"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,6 @@ jobs:
     secrets: inherit
     with:
       runsonlabels: '["macos-12"]'
-      scheme: TemplateApplication
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'bundler install && bundle exec fastlane test'"
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,7 @@ jobs:
       fastlanelane: test
   uploadcoveragereport:
     name: Upload Coverage Report
+    needs: buildandtest
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@selfHostedCI
     with:
       coveragereports: TemplateApplication.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
     secrets: inherit
     with:
-      runsonlabels: '["macos-12", "self-hosted"]'
+      runsonlabels: '["macOS", "self-hosted"]'
       scheme: TemplateApplication
       fastlanelane: test
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
   buildandtest:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
@@ -31,7 +31,7 @@ jobs:
       customcommand: "firebase emulators:exec 'fastlane test'"
   buildandtestongithub:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@selfHostedCI
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
@@ -41,6 +41,6 @@ jobs:
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: buildandtest
-    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@selfHostedCI
+    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: TemplateApplication.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,8 @@ jobs:
     with:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: TemplateApplication
-      fastlanelane: test
+      setupfirebaseemulator: true
+      customcommand: "firebase emulators:exec 'bundler install && bundle exec fastlane test'"
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: buildandtest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       artifactname: TemplateApplication.xcresult
-      runsonlabels: '["macos-latest", "self-hosted"]'
+      runsonlabels: '["macOS", "self-hosted"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
   uploadcoveragereport:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,6 @@ jobs:
     secrets: inherit
     with:
       runsonlabels: '["macOS", "self-hosted"]'
-      scheme: TemplateApplication
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
   buildandtestongithub:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Swift Package Manager
 *.xcodeproj
 .swiftpm
+.derivedData
 .build/
 !TemplateApplication.xcodeproj
 

--- a/TemplateApplication.xcodeproj/project.pbxproj
+++ b/TemplateApplication.xcodeproj/project.pbxproj
@@ -863,7 +863,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTHealthKit";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.2;
+				minimumVersion = 0.3.3;
 			};
 		};
 		2FEE103B2998E580000822E1 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {

--- a/TemplateApplication.xcodeproj/project.pbxproj
+++ b/TemplateApplication.xcodeproj/project.pbxproj
@@ -855,7 +855,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/CardinalKit";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.0;
+				minimumVersion = 0.3.2;
 			};
 		};
 		2F4E237F2989C5930013F3D9 /* XCRemoteSwiftPackageReference "XCTHealthKit" */ = {
@@ -863,7 +863,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTHealthKit";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.0;
+				minimumVersion = 0.3.2;
 			};
 		};
 		2FEE103B2998E580000822E1 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {

--- a/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTHealthKit",
       "state" : {
-        "revision" : "87f5c8e462724e7283205fc15e840031919fe31d",
-        "version" : "0.3.2"
+        "revision" : "19395bbd14a2554e4c9d3fe5cf38aa626c807269",
+        "version" : "0.3.3"
       }
     }
   ],

--- a/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TemplateApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/CardinalKit",
       "state" : {
-        "revision" : "f86fd8e39b64c685ee57e691b84f1cf851c146ae",
-        "version" : "0.3.0"
+        "revision" : "5ad27f4b7c47d9d3ab1435eb55bcd3db139dbd8b",
+        "version" : "0.3.2"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTHealthKit",
       "state" : {
-        "revision" : "70b79e67339da1174e6f7dcd58d6c041388ded96",
-        "version" : "0.3.1"
+        "revision" : "87f5c8e462724e7283205fc15e840031919fe31d",
+        "version" : "0.3.2"
       }
     }
   ],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,7 @@ platform :ios do
   lane :test do
     run_tests(
       code_coverage: true,
+      derived_data_path: ".derivedData",
       result_bundle: true,
       output_directory: "."
     )
@@ -25,7 +26,9 @@ platform :ios do
 
   desc "Build app"
   lane :build do
-    build_app
+    build_app(
+      derived_data_path: ".derivedData"
+    )
   end
 
   desc "Sign in to the App Store Connect API"
@@ -43,7 +46,7 @@ platform :ios do
     signin
     increment_build_number({
       build_number: latest_testflight_build_number + 1,
-      xcodeproj: "TemplateApplication.xcodeproj"
+      xcodeproj: "GetMoovin.xcodeproj"
     })
     build
     upload_to_testflight

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,6 +49,16 @@ platform :ios do
       xcodeproj: "TemplateApplication.xcodeproj"
     })
     build
-    upload_to_testflight
+    commit = last_git_commit
+    upload_to_testflight(
+      distribute_external: true,
+      groups: [
+        "External Testers"
+      ],
+      submit_beta_review: true,
+      notify_external_testers: true,
+      expire_previous_builds: true,
+      changelog: commit[:message]
+    )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,7 +46,7 @@ platform :ios do
     signin
     increment_build_number({
       build_number: latest_testflight_build_number + 1,
-      xcodeproj: "GetMoovin.xcodeproj"
+      xcodeproj: "TemplateApplication.xcodeproj"
     })
     build
     upload_to_testflight


### PR DESCRIPTION
# Improve CI & CD

## :recycle: Current situation & Problem
The current CI setup is custom-build for the template application and relies on GitHub Action runners hosted by GitHub. 

## :bulb: Proposed solution
- This PR moves most of the logic to the shared repository in the Stanford Biodesign Digital Health Organization.
- Adds the ability to run the CI/CD on self-hosted runners.
- Speeds the builds up using a build cache.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

