### PR TITLE
Prevent onboarding flow from being dismissed until complete

### DIFF
--- a/TemplateApplicationModules/Sources/TemplateOnboardingFlow/OnboardingFlow.swift
+++ b/TemplateApplicationModules/Sources/TemplateOnboardingFlow/OnboardingFlow.swift
@@ -21,8 +21,8 @@ public struct OnboardingFlow: View {
         case healthKitPermissions
     }
     
-    
     @SceneStorage(StorageKeys.onboardingFlowStep) private var onboardingSteps: [Step] = []
+    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
     
     
     public var body: some View {
@@ -46,6 +46,7 @@ public struct OnboardingFlow: View {
                 }
                 .navigationBarTitleDisplayMode(.inline)
         }
+        .interactiveDismissDisabled(!completedOnboardingFlow)
     }
     
     


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Prevent onboarding flow from being dismissed until complete

## :recycle: Current situation & Problem
Currently, the sheet presenting the onboarding flow can be dismissed before onboarding is complete, allowing a user to access the application without completing the consent process or logging in. This behavior should not be possible.

## :bulb: Proposed solution
This PR prevents the onboarding flow sheet from being dismissed until all steps in onboarding are complete.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

