### PR TITLE
Add auto emulator/production switching for firebase based on build scheme

### DIFF
--- a/TemplateApplication/TemplateAppDelegate.swift
+++ b/TemplateApplication/TemplateAppDelegate.swift
@@ -27,7 +27,13 @@ class TemplateAppDelegate: CardinalKitAppDelegate {
     override var configuration: Configuration {
         Configuration(standard: FHIR()) {
             if !CommandLine.arguments.contains("--disableFirebase") {
+                // If debug scheme, use Firebase authentication emulator. If release scheme,
+                // use cloud live authentication in production project
+                #if DEBUG
                 FirebaseAccountConfiguration(emulatorSettings: (host: "localhost", port: 9099))
+                #else
+                FirebaseAccountConfiguration()
+                #endif
                 firestore
             }
             if HKHealthStore.isHealthDataAvailable() {
@@ -41,13 +47,24 @@ class TemplateAppDelegate: CardinalKitAppDelegate {
     
     
     private var firestore: Firestore<FHIR> {
+        // If debug scheme, use Firebase firestore emulator. If release scheme,
+        // use cloud live firestore in production project
+        #if DEBUG
         Firestore(
             adapter: {
                 FHIRToFirestoreAdapter()
                 FirestoreStoragePrefixUserIdAdapter()
             },
-            settings: .emulator
+            settings: .emulator // sets up firestore simulator
         )
+        #else
+        Firestore(
+            adapter: {
+                FHIRToFirestoreAdapter()
+                FirestoreStoragePrefixUserIdAdapter()
+            }
+        )
+        #endif
     }
     
     


### PR DESCRIPTION
# Add auto emulator/production switching for firebase based on build scheme

## :recycle: Current situation & Problem
- Currently, all calls to firebase from the project are configured to go to the local firebase emulator suite, and will require manually changing the Firebase authentication and Firestore code in order to make calls directly to the cloud/live Firebase project associated with the app.

## :bulb: Proposed solution
- Using the `#if DEBUG` compiler directive, configure Firestore to automatically make call calls to the local emulators when built using the debug scheme, and directly to the live/cloud Firebase project when building with the release (or any other) scheme.

### Reviewer Nudging
- Does this change follow CardinalKit's conventions?

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

