### PR TITLE
Disable unintended "pull down to dismiss" for sign-in modal view

### DIFF
--- a/TemplateApplication/TemplateApplication.swift
+++ b/TemplateApplication/TemplateApplication.swift
@@ -22,7 +22,7 @@ struct TemplateApplication: App {
         WindowGroup {
             HomeView()
                 .sheet(isPresented: !$completedOnboardingFlow) {
-                    OnboardingFlow()
+                    OnboardingFlow().interactiveDismissDisabled(true)
                 }
                 .testingSetup()
                 .cardinalKit(appDelegate)


### PR DESCRIPTION
To prevent the user from bypassing the sign-in/account creation process and jumping straight into the “Scheudle” page without an account signed in by dragging the sign-in modal view down and dismissing it.

# Disable "pull down to dismiss" for sign-in modal view

## :recycle: Current situation & Problem
- Since `TemplateOnboardingFlow` uses a ModalView/sheet to display the onboarding/account-sign-in/creation process, the user can swipe down on the modal sheet to dismiss the process anytime during the process and enter the app's main interact without an account sign-ed in (effectively the same as using the launch argument `--skipOnboarding`).

![small_modal_image](https://user-images.githubusercontent.com/50314114/224573359-1482460b-94ed-42ad-85fa-19b84713e640.png)

## :bulb: Proposed solution
- Added modifier `.interactiveDismissDisabled(true)` to make the Modal View un-dismissible until the intended end of the onboarding flow.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).