### PR TITLE
Prevent HomeView onAppear code from running until onboarding is complete

### DIFF
--- a/TemplateApplication/TemplateApplication.swift
+++ b/TemplateApplication/TemplateApplication.swift
@@ -18,7 +18,13 @@ struct TemplateApplication: App {
     
     var body: some Scene {
         WindowGroup {
-            HomeView()
+            Group {
+                if completedOnboardingFlow {
+                    HomeView()
+                } else {
+                    EmptyView()
+                }
+            }
                 .sheet(isPresented: !$completedOnboardingFlow) {
                     OnboardingFlow()
                 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Prevent HomeView onAppear code from running until onboarding is complete

## :recycle: Current situation & Problem
`HomeView` is currently rendered in the background behind the `OnboardingFlow` sheet. If `HomeView` contains code attached to the `onAppear` event that requires onboarding to be complete (i.e. a logged in user) it will fail.

## :bulb: Proposed solution
This PR renders an `EmptyView` behind the `OnboardingFlow` sheet until the `completedOnboardingFlow` flag is true. This prevents any `onAppear` code in `HomeView` from running until the user has fully onboarded.

Thank you @PSchmiedmayer for your assistance with debugging this issue.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

